### PR TITLE
bump audiotools version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     keywords=["audio", "compression", "machine learning"],
     install_requires=[
         "argbind>=0.3.7",
-        "descript-audiotools==0.7.1",
+        "descript-audiotools @ git+https://github.com/descriptinc/audiotools.git@0.7.2",
         "einops",
         "numpy",
         "torch",


### PR DESCRIPTION
bumps the `audiotools` version to `0.7.2`, which fixes a bug related to the files api: https://github.com/descriptinc/audiotools/releases/tag/0.7.2