### PR TITLE
fix DecoderBlock bug

### DIFF
--- a/dac/model/dac.py
+++ b/dac/model/dac.py
@@ -102,6 +102,7 @@ class DecoderBlock(nn.Module):
                 kernel_size=2 * stride,
                 stride=stride,
                 padding=math.ceil(stride / 2),
+                output_padding=1,
             ),
             ResidualUnit(output_dim, dilation=1),
             ResidualUnit(output_dim, dilation=3),


### PR DESCRIPTION
Fix shape mismatch bug reported in [issue42](https://github.com/descriptinc/descript-audio-codec/issues/42) caused by DecoderBlock when stride is odd. For example: when kernel_size=10, stride=5