### PR TITLE
change default win_duration to 5.0

### DIFF
--- a/dac/model/base.py
+++ b/dac/model/base.py
@@ -126,7 +126,7 @@ class CodecMixin:
     def compress(
         self,
         audio_path_or_signal: Union[str, Path, AudioSignal],
-        win_duration: float = 1.0,
+        win_duration: float = 5.0,
         verbose: bool = False,
         normalize_db: float = -16,
         n_quantizers: int = None,

--- a/dac/model/dac.py
+++ b/dac/model/dac.py
@@ -102,6 +102,7 @@ class DecoderBlock(nn.Module):
                 kernel_size=2 * stride,
                 stride=stride,
                 padding=math.ceil(stride / 2),
+                output_padding=1, # https://github.com/descriptinc/descript-audio-codec/pull/44/files
             ),
             ResidualUnit(output_dim, dilation=1),
             ResidualUnit(output_dim, dilation=3),


### PR DESCRIPTION
Reverting Default 'win_duration' Value to 5.0
- Initially, 'win_duration' was set to 1.0 by default.
- This default setting significantly reduced performance in audio-related tasks.
- Aligning with the documentation, the 'win_duration' value should be 5.0."