### PR TITLE
Fix how n_quantizers is used in compress function

### DIFF
--- a/dac/model/base.py
+++ b/dac/model/base.py
@@ -215,6 +215,9 @@ class CodecMixin:
 
         codes = torch.cat(codes, dim=-1)
 
+        if n_quantizers is not None:
+            codes = codes[:, :n_quantizers, :]
+        
         dac_file = DACFile(
             codes=codes,
             chunk_length=chunk_length,
@@ -225,9 +228,6 @@ class CodecMixin:
             padding=self.padding,
             dac_version=SUPPORTED_VERSIONS[-1],
         )
-
-        if n_quantizers is not None:
-            codes = codes[:, :n_quantizers, :]
 
         self.padding = original_padding
         return dac_file


### PR DESCRIPTION
I think a code snippet was in the wrong place. Now it restricts the number of quantizers before creating the DAC file.