### PR TITLE
Fixes wrong output dimensions in ConvTranspose1d

### DIFF
--- a/dac/model/dac.py
+++ b/dac/model/dac.py
@@ -196,10 +196,9 @@ class DAC(BaseModel, CodecMixin):
 
         self.delay = self.get_delay()
 
-    def preprocess(self, audio_data, sample_rate):
-        if sample_rate is None:
-            sample_rate = self.sample_rate
-        assert sample_rate == self.sample_rate
+    def preprocess(self, audio_data, sample_rate=None):
+        if sample_rate:
+            assert sample_rate == self.sample_rate, f'Expected sample rate is {self.sample_rate}'
 
         length = audio_data.shape[-1]
         right_pad = math.ceil(length / self.hop_length) * self.hop_length - length

--- a/dac/model/dac.py
+++ b/dac/model/dac.py
@@ -102,6 +102,7 @@ class DecoderBlock(nn.Module):
                 kernel_size=2 * stride,
                 stride=stride,
                 padding=math.ceil(stride / 2),
+                output_padding=0 if stride % 2 == 0 else 1
             ),
             ResidualUnit(output_dim, dilation=1),
             ResidualUnit(output_dim, dilation=3),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="descript-audio-codec",
-    version="1.0.0",
+    version="1.0.1",
     classifiers=[
         "Intended Audience :: Developers",
         "Natural Language :: English",


### PR DESCRIPTION
Solves #42, #58 and #68: all related to incorrect computation of output shape in the ConvTraspose1d of the DecoderBlock (as also pointed out in PR #44).

When using stride > 1 in a conv operation the output dimensions are underdetermined and ConvTranspose1d needs extra info (the output_padding) to compute the expected output (see note in [docs](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose1d.html)).

Given the construction constraints of the conv/deconv operations (namely, kernel_size=stride/2, padding=ceil(stride/2)), I figured out the right output_padding (so we always recover the same input dimensions) is:
```
if s is even:
	output_padding = 0 if input_timesteps is divisible by stride, else 1
If stride is odd:
	output_padding = 0  if input_timesteps + 1 is divisible by stride, else 1
```
with input_timesteps = timestestep dimension of the input to the original conv1d.

This PR sets output_padding=0 for even strides and 1 for odd strides. This will work in the vast majority of cases (including for all pretrained models) except when:
1: if stride is even and input_timesteps is not divisible by stride. 
2: if stride is odd and input_timesteps+1 is divisible by stride.
Both of which are unlikely ( and case 1 would fail anyway even without this PR). At the very least, I believe the current setting is a more sensible default.