### PR TITLE
Making DAC decoder torch.compileable

### DIFF
--- a/dac/model/discriminator.py
+++ b/dac/model/discriminator.py
@@ -5,7 +5,7 @@ from audiotools import AudioSignal
 from audiotools import ml
 from audiotools import STFTParams
 from einops import rearrange
-from torch.nn.utils import weight_norm
+from torch.nn.utils.parametrizations import weight_norm
 
 
 def WNConv1d(*args, **kwargs):

--- a/dac/nn/layers.py
+++ b/dac/nn/layers.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
-from torch.nn.utils import weight_norm
+from torch.nn.utils.parametrizations import weight_norm
 
 
 def WNConv1d(*args, **kwargs):

--- a/dac/nn/quantize.py
+++ b/dac/nn/quantize.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
-from torch.nn.utils import weight_norm
 
 from dac.nn.layers import WNConv1d
 


### PR DESCRIPTION
The original torch.nn.utils.weight_norm() function is deprecated and it prevents the DAC decoder model from being torch.compiled. The newer torch.nn.utils.parametrizations.weight_norm() works the same way as the old one and plus it is compatible with torch.compile (with CUDA graphs).